### PR TITLE
Add regex check for Cell line samples when checking for label updates

### DIFF
--- a/src/main/java/org/mskcc/smile/service/impl/CmoLabelGeneratorServiceImpl.java
+++ b/src/main/java/org/mskcc/smile/service/impl/CmoLabelGeneratorServiceImpl.java
@@ -110,8 +110,21 @@ public class CmoLabelGeneratorServiceImpl implements CmoLabelGeneratorService {
      */
     @Override
     public Boolean igoSampleRequiresLabelUpdate(String newCmoLabel, String existingCmoLabel) {
+        // if the labels match then just return false
+        if (newCmoLabel.equals(existingCmoLabel)) {
+            return Boolean.FALSE;
+        }
+        // proceed with regular (non-cell line) cmo sample label checking
+        Matcher matcherNewCelllineLabel = CMO_CELLLINE_ID_REGEX.matcher(newCmoLabel);
         Matcher matcherNewLabel = CMO_SAMPLE_ID_REGEX.matcher(newCmoLabel);
         Matcher matcherExistingLabel = CMO_SAMPLE_ID_REGEX.matcher(existingCmoLabel);
+
+        // if we have a cell line sample and the existing and new label generated do not match
+        // then return true so that we update to the new cmo label generated
+        if (matcherNewCelllineLabel.find() && !matcherNewLabel.find()) {
+            return Boolean.TRUE;
+        }
+
         if (!matcherNewLabel.find() || !matcherExistingLabel.find()) {
             throw new IllegalStateException("New CMO label and/or existing CMO label do not meet CMO ID "
                     + "regex requirements: new = " + newCmoLabel + ", existingLabel = " + existingCmoLabel);


### PR DESCRIPTION
Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>

# Bug fix for handling checks for Cell line samples with label updates

Briefly describe changes proposed in this pull request:
- Handle checks for updated labels for cell line samples

---
## Crossing T's and dotting I's

Please follow these checklists to help prevent any unexpected issues from being introduced by the changes in this pull request. If an item does not apply then indicate so by surrounding the line item with `~~` to strikethrough the text. See [basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for more information.

### I. Data model checklist
Please follow these checks if any changes were made to any classes in the web, service, or persistence layers.

**Data checks:** `N/A`
Updates were made to the mocked incoming request data and/or mocked published request data:
```
- [ ] [smile-server test data](https://github.com/mskcc/smile-server/tree/master/service/src/test/resources/data)
- [ ] [smile-commons test data](https://github.com/mskcc/smile-commons/tree/master/src/test/resources/data)
- [ ] [smile-label-generator test data](https://github.com/mskcc/smile-label-generator/tree/master/src/test/resources/data)
- [ ] [smile-request-filter test data](https://github.com/mskcc/smile-request-filter/tree/master/src/test/resources/data)

**Code checks:**
- [ ] Unit tests were updated in relation to updates to the mocked test data.
```
### II. Message handlers checklist: N/A

- [n/a] ~~Changes introduced affect the workflow of incoming messages.~~
- [n/a] ~~Messages are following the expected workflow when published to the topic(s) changed or introduced in this pull request.~~
- [x] Unit tests were added or updated to ensure messages are handled as expected.

If no unit tests were updated or added, then please explain why: [insert details here]

Please describe how the workflow and messaging was tested/simulated:

**Describe your testing environment:**

- NATS [local, **local docker**, dev server, production]
- Neo4j [local, **local docker**, dev server, production]
- SMILE Server [local, **local docker**, dev server, production]
- Message publishing simulation [nats cli, docker nats cli, **smile publisher tool**, other (describe below)]

Other: [insert details on how messages were published or simulated for testing]

### II. Configuration and/or permissions checklist: N/A
```
- [ ] New topics were introduced.
- [ ] The topics and appropriate permissions were updated in [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration).
- [ ] If applicable, a new account was set up and the account credentials and keys are checked into [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration).
- [ ] Account credentials and keys were shared with the appropriate parties.
```
---
### General checklist:
- [ ] All requested changes and comments have been resolved.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
