### PR TITLE
Autowired exception fix

### DIFF
--- a/src/main/java/org/mskcc/smile/service/util/RequestStatusLogger.java
+++ b/src/main/java/org/mskcc/smile/service/util/RequestStatusLogger.java
@@ -25,7 +25,6 @@ public class RequestStatusLogger {
 
     private File requestStatusLoggerFile;
 
-    @Autowired
     private static final String[] REQUEST_LOGGER_FILE_HEADER = new String[]{"DATE", "STATUS", "MESSAGE"};
 
     /**


### PR DESCRIPTION
Resolves the following error message:

```
2022-08-04 14:47:48.183  INFO 49158 --- [           main] f.a.AutowiredAnnotationBeanPostProcessor : 
Autowired annotation is not supported on static fields: private static final java.lang.String[] 
org.mskcc.smile.service.util.RequestStatusLogger.REQUEST_LOGGER_FILE_HEADER
```

Signed-off-by: Divya Madala <71040191+divyamadala30@users.noreply.github.com>
