### PR TITLE
Default F sample type abbreviation

### DIFF
--- a/src/main/java/org/mskcc/smile/service/CmoLabelGeneratorService.java
+++ b/src/main/java/org/mskcc/smile/service/CmoLabelGeneratorService.java
@@ -19,4 +19,6 @@ public interface CmoLabelGeneratorService {
     Status generateSampleStatus(SampleMetadata sampleMetadata,
             List<SampleMetadata> existingSamples) throws JsonProcessingException;
     Boolean igoSampleRequiresLabelUpdate(String newCmoLabel, String existingCmoLabel);
+    String resolveSampleTypeAbbreviation(String specimenTypeValue, String sampleOriginValue,
+            String cmoSampleClassValue);
 }

--- a/src/main/java/org/mskcc/smile/service/impl/LabelGenMessageHandlingServiceImpl.java
+++ b/src/main/java/org/mskcc/smile/service/impl/LabelGenMessageHandlingServiceImpl.java
@@ -28,7 +28,6 @@ import org.mskcc.smile.model.Status;
 import org.mskcc.smile.model.igo.IgoSampleManifest;
 import org.mskcc.smile.service.CmoLabelGeneratorService;
 import org.mskcc.smile.service.MessageHandlingService;
-import org.mskcc.smile.service.util.RequestStatusLogger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;

--- a/src/test/java/org/mskcc/smile/CmoLabelGeneratorServiceTest.java
+++ b/src/test/java/org/mskcc/smile/CmoLabelGeneratorServiceTest.java
@@ -182,7 +182,7 @@ public class CmoLabelGeneratorServiceTest {
         // if the cmo label before the update is C-MP789JR-X001-d
         Assert.assertEquals("C-newPatient-X001-d02", newCmoLabel);
 
-        
+
         Status sampleStatus = cmoLabelGeneratorService.generateSampleStatus(
                 updatedSample, existingSamples);
         Assert.assertEquals(Boolean.TRUE, sampleStatus.getValidationStatus());
@@ -226,7 +226,7 @@ public class CmoLabelGeneratorServiceTest {
         // should return null string
         String newCmoLabel = cmoLabelGeneratorService.generateCmoSampleLabel(
                 updatedSample, existingSamples);
-        Assert.assertNull(newCmoLabel);
+        Assert.assertEquals("C-MP789JR-F001-d01", newCmoLabel);
 
         Status sampleStatus = cmoLabelGeneratorService.generateSampleStatus(
                 updatedSample, existingSamples);
@@ -268,6 +268,13 @@ public class CmoLabelGeneratorServiceTest {
         Assert.assertEquals(sampleExpectedLabel, sampleUpdatedNaExtractLabel);
         Assert.assertFalse(cmoLabelGeneratorService.igoSampleRequiresLabelUpdate(
                 sampleUpdatedNaExtractLabel, sampleExpectedLabel));
+    }
+
+    @Test
+    public void testDefaultSampleTypeAbbreviation() {
+        String sampleTypeAbbrev = cmoLabelGeneratorService.resolveSampleTypeAbbreviation("RapidAutopsy",
+                "Cerebrospinal Fluid", "Other");
+        Assert.assertTrue(sampleTypeAbbrev.equals("F"));
     }
 
     private IgoSampleManifest getSampleMetadata(String igoId, String cmoPatientId,


### PR DESCRIPTION
# Support "F" as default sample type abbreviation

Briefly describe changes proposed in this pull request:
- Use "F" as default sample type abbreviation

---
## Crossing T's and dotting I's

Please follow these checklists to help prevent any unexpected issues from being introduced by the changes in this pull request. If an item does not apply then indicate so by surrounding the line item with `~~` to strikethrough the text. See [basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for more information.

### I. Data model checklist
Please follow these checks if any changes were made to any classes in the web, service, or persistence layers.

**Data checks:**
Updates were made to the mocked incoming request data and/or mocked published request data:

- ~~[ ] [smile-server test data](https://github.com/mskcc/smile-server/tree/master/service/src/test/resources/data)~~
- ~~[ ] [smile-commons test data](https://github.com/mskcc/smile-commons/tree/master/src/test/resources/data)~~
- ~~[ ] [smile-label-generator test data](https://github.com/mskcc/smile-label-generator/tree/master/src/test/resources/data)~~
- ~~[ ] [smile-request-filter test data](https://github.com/mskcc/smile-request-filter/tree/master/src/test/resources/data)~~

**Code checks:**
- [x] Unit tests were updated in relation to updates to the mocked test data.

### II. Message handlers checklist:
- ~~[ ] Changes introduced affect the workflow of incoming messages.~~
- ~~[ ] Messages are following the expected workflow when published to the topic(s) changed or introduced in this pull request.~~
- [x] Unit tests were added or updated to ensure messages are handled as expected.

If no unit tests were updated or added, then please explain why: [insert details here]

Please describe how the workflow and messaging was tested/simulated:

**Describe your testing environment:**

- NATS [local, local docker, dev server, production]
- Neo4j [local, local docker, dev server, production]
- SMILE Server [local, local docker, dev server, production]
- Message publishing simulation [nats cli, docker nats cli, smile publisher tool, other (describe below)]

Other: [insert details on how messages were published or simulated for testing]

### II. Configuration and/or permissions checklist:
- ~~[ ] New topics were introduced.~~
- ~~[ ] The topics and appropriate permissions were updated in [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration).~~
- ~~[ ] If applicable, a new account was set up and the account credentials and keys are checked into [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration).~~
- ~~[ ] Account credentials and keys were shared with the appropriate parties.~~

---
### General checklist:
- [ ] All requested changes and comments have been resolved.
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
