### PR TITLE
Bug fix when sampleClass is not a known class

### DIFF
--- a/src/main/java/org/mskcc/smile/service/impl/CmoLabelGeneratorServiceImpl.java
+++ b/src/main/java/org/mskcc/smile/service/impl/CmoLabelGeneratorServiceImpl.java
@@ -388,12 +388,21 @@ public class CmoLabelGeneratorServiceImpl implements CmoLabelGeneratorService {
         }
 
         // if abbreviation is still not resolved then try to resolve from sample class
-        CmoSampleClass sampleClass = CmoSampleClass.fromValue(cmoSampleClassValue);
-        String sampleTypeAbbreviation = SAMPLE_CLASS_ABBREV_MAP.get(sampleClass);
-        if (sampleTypeAbbreviation == null) {
+        String sampleTypeAbbreviation = "F";
+        try {
+            CmoSampleClass sampleClass = CmoSampleClass.fromValue(cmoSampleClassValue);
+            if (SAMPLE_CLASS_ABBREV_MAP.containsKey(sampleClass)) {
+                sampleTypeAbbreviation = SAMPLE_CLASS_ABBREV_MAP.get(sampleClass);
+            }
+        } catch (Exception e) {
+            // happens if cmoSampleClassValue is not found in CmoSampleClass
+            // nothing to do here since since sampleTypeAbbreviation
+            // is initialized to default 'F'
+        }
+
+        if (sampleTypeAbbreviation == "F") {
             LOG.warn("Could not resolve sample type abbreviation from specimen type,"
-                    + " sample origin, or sample class - using default 'F' ");
-            return "F";
+                     + " sample origin, or sample class - using default 'F' ");
         }
         return sampleTypeAbbreviation;
     }


### PR DESCRIPTION
# A descriptive title

Briefly describe changes proposed in this pull request:

During sample label generation a runtime exception is thrown when an unknown sample class is processed.  This code catches the exception and sets the sampleLabelAbbreviation to the default value "F" in this situation.

```
java.lang.RuntimeException: Unsupported CMO Sample Class: Unknown
	at org.mskcc.smile.commons.enums.CmoSampleClass.fromValue(CmoSampleClass.java:44) ~[smile-commons-1.3.11.RELEASE.jar!/:1.1.0-SNAPSHOT]
	at org.mskcc.smile.service.impl.CmoLabelGeneratorServiceImpl.resolveSampleTypeAbbreviation(CmoLabelGeneratorServiceImpl.java:391) ~[classes!/:0.1.0]
	at org.mskcc.smile.service.impl.CmoLabelGeneratorServiceImpl.resolveSampleTypeAbbreviation(CmoLabelGeneratorServiceImpl.java:407) ~[classes!/:0.1.0]
	at org.mskcc.smile.service.impl.CmoLabelGeneratorServiceImpl.generateCmoSampleLabel(CmoLabelGeneratorServiceImpl.java:174) ~[classes!/:0.1.0]
	at org.mskcc.smile.service.impl.LabelGenMessageHandlingServiceImpl$CmoLabelGeneratorHandler.run(LabelGenMessageHandlingServiceImpl.java:229) ~[classes!/:0.1.0]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[na:na]
	at java.base/java.lang.Thread.run(Thread.java:834) ~[na:na]
```