### PR TITLE
Bug fix: validationReport interpretation fix

### DIFF
--- a/src/main/java/org/mskcc/smile/service/impl/CmoLabelGeneratorServiceImpl.java
+++ b/src/main/java/org/mskcc/smile/service/impl/CmoLabelGeneratorServiceImpl.java
@@ -623,8 +623,8 @@ public class CmoLabelGeneratorServiceImpl implements CmoLabelGeneratorService {
                             Map.class);
                     Map<String, String> sampleValidationReport = new HashMap<>();
                     if (!sampleStatusMap.get("validationReport").toString().equals("{}")) {
-                        sampleValidationReport =
-                                mapper.convertValue(sampleStatusMap.get("validationReport"), Map.class);
+                        sampleValidationReport = mapper.readValue(
+                                sampleStatusMap.get("validationReport").toString(), Map.class);
                     }
 
                     try {


### PR DESCRIPTION
Stack trace:

```
com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot construct instance of `java.util.LinkedHashMap` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('{"fastQs":"missing","igoComplete":"false"}')
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 1]
	at com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:63) ~[jackson-databind-2.17.2.jar!/:2.17.2]
	at com.fasterxml.jackson.databind.DeserializationContext.reportInputMismatch(DeserializationContext.java:1754) ~[jackson-databind-2.17.2.jar!/:2.17.2]
	at com.fasterxml.jackson.databind.DeserializationContext.handleMissingInstantiator(DeserializationContext.java:1379) ~[jackson-databind-2.17.2.jar!/:2.17.2]
	at com.fasterxml.jackson.databind.deser.std.StdDeserializer._deserializeFromString(StdDeserializer.java:311) ~[jackson-databind-2.17.2.jar!/:2.17.2]
	at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:454) ~[jackson-databind-2.17.2.jar!/:2.17.2]
	at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:32) ~[jackson-databind-2.17.2.jar!/:2.17.2]
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:342) ~[jackson-databind-2.17.2.jar!/:2.17.2]
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4905) ~[jackson-databind-2.17.2.jar!/:2.17.2]
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3848) ~[jackson-databind-2.17.2.jar!/:2.17.2]
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3816) ~[jackson-databind-2.17.2.jar!/:2.17.2]
	at org.mskcc.smile.service.impl.CmoLabelGeneratorServiceImpl.generateValidationReport(CmoLabelGeneratorServiceImpl.java:630) ~[!/:0.1.0]
	at org.mskcc.smile.service.impl.LabelGenMessageHandlingServiceImpl$CmoLabelGeneratorHandler.run(LabelGenMessageHandlingServiceImpl.java:319) ~[!/:0.1.0]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[na:na]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[na:na]
```
