### PR TITLE
Increment nucleic acid counter if duplicate found

### DIFF
--- a/src/main/java/org/mskcc/smile/service/CmoLabelGeneratorService.java
+++ b/src/main/java/org/mskcc/smile/service/CmoLabelGeneratorService.java
@@ -23,4 +23,5 @@ public interface CmoLabelGeneratorService {
             String cmoSampleClassValue);
     String generateValidationReport(String originalJson, String filteredJson, Boolean isSample)
             throws JsonProcessingException;
+    String incrementNucleicAcidCounter(String cmoLabel);
 }

--- a/src/main/java/org/mskcc/smile/service/impl/CmoLabelGeneratorServiceImpl.java
+++ b/src/main/java/org/mskcc/smile/service/impl/CmoLabelGeneratorServiceImpl.java
@@ -682,4 +682,35 @@ public class CmoLabelGeneratorServiceImpl implements CmoLabelGeneratorService {
     private Boolean isBlank(String value) {
         return (Strings.isBlank(value) || value.equals("null"));
     }
+
+    @Override
+    public String incrementNucleicAcidCounter(String cmoLabel) {
+        Matcher matcher = CMO_SAMPLE_ID_REGEX.matcher(cmoLabel);
+        // first make sure that we are dealing with a "C-" style label
+        if (!matcher.find()) {
+            return null;
+        }
+
+        // parse the nucleic acid counter group
+        Integer nucAcidIncrement;
+        if (matcher.group(CMO_SAMPLE_NUCACID_COUNTER_GROUP) == null
+                || matcher.group(CMO_SAMPLE_NUCACID_COUNTER_GROUP).isEmpty()) {
+            nucAcidIncrement = 1;
+        } else {
+            nucAcidIncrement = Integer.valueOf(matcher.group(CMO_SAMPLE_NUCACID_COUNTER_GROUP));
+        }
+        // we only call this function when the nuc acid counter needs to be incremented
+        nucAcidIncrement++;
+        String paddedNucAcidCounter = getPaddedIncrementString(nucAcidIncrement,
+                CMO_SAMPLE_NUCACID_COUNTER_PADDING);
+
+        // everything else in the label can remain as is
+        String patientId = "C-" + matcher.group(CMO_PATIENT_ID_GROUP);
+        String sampleTypeAbbreviation = matcher.group(CMO_SAMPLE_TYPE_ABBREV_GROUP);
+        String paddedSampleCounter = matcher.group(CMO_SAMPLE_COUNTER_GROUP);
+        String nucleicAcidAbbreviation = matcher.group(CMO_SAMPLE_NUCACID_ABBREV_GROUP);
+
+        return getFormattedCmoSampleLabel(patientId, sampleTypeAbbreviation, paddedSampleCounter,
+                nucleicAcidAbbreviation, paddedNucAcidCounter);
+    }
 }

--- a/src/test/java/org/mskcc/smile/CmoLabelGeneratorServiceTest.java
+++ b/src/test/java/org/mskcc/smile/CmoLabelGeneratorServiceTest.java
@@ -274,6 +274,30 @@ public class CmoLabelGeneratorServiceTest {
         Assertions.assertTrue(sampleTypeAbbrev.equals("F"));
     }
 
+    /**
+     * Tests the behavior of the nucleic acid increment method.
+     * @throws Exception
+     */
+    @Test
+    public void testIncrementNucleicAcidCounter() throws Exception {
+        // test label increment when nuc acid counter isn't present
+        String legacyLabel = "C-MP789JR-F001-d";
+        String expectedIncrementLegacy = "C-MP789JR-F001-d02";
+        String actualIncrementLegacy = cmoLabelGeneratorService.incrementNucleicAcidCounter(legacyLabel);
+        Assertions.assertEquals(expectedIncrementLegacy, actualIncrementLegacy);
+
+        // test increment with a non-legacy label
+        String inputLabel = "C-MP789JR-F001-d01";
+        String expectedLabel = "C-MP789JR-F001-d02";
+        String actualLabel = cmoLabelGeneratorService.incrementNucleicAcidCounter(inputLabel);
+        Assertions.assertEquals(expectedLabel, actualLabel);
+
+        // test another increment
+        String nextExpectedLabel = "C-MP789JR-F001-d03";
+        String nextActualLabel = cmoLabelGeneratorService.incrementNucleicAcidCounter(expectedLabel);
+        Assertions.assertEquals(nextExpectedLabel, nextActualLabel);
+    }
+
     private IgoSampleManifest getSampleMetadata(String igoId, String cmoPatientId,
             SpecimenType specimenType, NucleicAcid naToExtract, String investigatorSampleId) {
         IgoSampleManifest sample = new IgoSampleManifest();


### PR DESCRIPTION
# Increment nucleic acid counter if duplicate found

Briefly describe changes proposed in this pull request:
- label generator will keep incrementing the nuc acid counter until encountering label that is available. This is only called when a duplicate label exists in SMILE for a different sample.
