### PR TITLE
Updated logic for resolving CMO label counters by ALT ID

### DIFF
--- a/src/main/java/org/mskcc/smile/service/CmoLabelGeneratorService.java
+++ b/src/main/java/org/mskcc/smile/service/CmoLabelGeneratorService.java
@@ -17,12 +17,15 @@ public interface CmoLabelGeneratorService {
     String generateCmoSampleLabel(SampleMetadata sample, List<SampleMetadata> existingPatientSamples,
             List<SampleMetadata> samplesByAltId);
     Status generateSampleStatus(String requestId, IgoSampleManifest sampleManifest,
-            List<SampleMetadata> existingSamples) throws JsonProcessingException;
-    Status generateSampleStatus(SampleMetadata sampleMetadata,
-            List<SampleMetadata> existingSamples) throws JsonProcessingException;
+            List<SampleMetadata> existingSamples, List<SampleMetadata> samplesByAltId)
+            throws JsonProcessingException;
+    Status generateSampleStatus(SampleMetadata sampleMetadata, List<SampleMetadata> existingSamples,
+            List<SampleMetadata> samplesByAltId) throws JsonProcessingException;
     Boolean igoSampleRequiresLabelUpdate(String newCmoLabel, String existingCmoLabel);
     String resolveSampleTypeAbbreviation(String specimenTypeValue, String sampleOriginValue,
             String cmoSampleClassValue);
+    String resolveSampleTypeAbbrevWithContext(String primaryId, String resolvedSampleTypeAbbrev,
+            List<SampleMetadata> samplesByAltId);
     String generateValidationReport(String originalJson, String filteredJson, Boolean isSample)
             throws JsonProcessingException;
     String incrementNucleicAcidCounter(String cmoLabel);

--- a/src/main/java/org/mskcc/smile/service/impl/LabelGenMessageHandlingServiceImpl.java
+++ b/src/main/java/org/mskcc/smile/service/impl/LabelGenMessageHandlingServiceImpl.java
@@ -242,7 +242,7 @@ public class LabelGenMessageHandlingServiceImpl implements MessageHandlingServic
                                         requestId, sampleManifest, existingSamples, samplesByAltId);
                                 if (newSampleCmoLabel == null) {
                                     sampleStatus = cmoLabelGeneratorService.generateSampleStatus(
-                                            requestId, sampleManifest, existingSamples);
+                                            requestId, sampleManifest, existingSamples, samplesByAltId);
                                     LOG.error("Unable to generate new CMO sample label for sample: "
                                             + sampleManifest.getIgoId());
                                     // check if we can fall back on an existing cmo label that might have
@@ -404,7 +404,7 @@ public class LabelGenMessageHandlingServiceImpl implements MessageHandlingServic
                         // Case when sample update json doesn't have status
                         if (sample.getStatus() == null) {
                             Status newSampleStatus = cmoLabelGeneratorService
-                                    .generateSampleStatus(sample, existingSamples);
+                                    .generateSampleStatus(sample, existingSamples, samplesByAltId);
                             sample.setStatus(newSampleStatus);
                         }
                         if (sample.getStatus().getValidationStatus()) {
@@ -414,7 +414,7 @@ public class LabelGenMessageHandlingServiceImpl implements MessageHandlingServic
                                             existingSamples, samplesByAltId);
                             if (newCmoSampleLabel == null) {
                                 Status newSampleStatus = cmoLabelGeneratorService
-                                        .generateSampleStatus(sample, existingSamples);
+                                        .generateSampleStatus(sample, existingSamples, samplesByAltId);
                                 sample.setStatus(newSampleStatus);
                             }
 


### PR DESCRIPTION
# Updated logic for resolving sample type abbreviations with added context from alt ids.

- Refactored nucleic acid counter resolution.
- Sample counter increment now takes into account other matching sample types when deciding what counter to assign the label being generated.

The changes in this PR are the result of a series of discussions with Project Managers and other CMO members. 

In summary, the following rules now apply when determining what sample counter should be assigned to new labels:
- Samples can exist in SMILE by a given ALT ID, meaning that the same ALT ID can be shared among multiple different IGO sample IDs (aka PRIMARY ID as they are known in SMILE). ALT ID is the identifier assigned to a source specimen acquired from a patient (such as tissue, liquid biopsy, etc.). The same specimen can be sequenced multiple times as part of separate Requests and will be assigned a new IGO ID for each sequencing assay it undergoes. 
- The sample counter will be based on a unique combination of the resolved sample type abbreviation and counter. This means that a patient can have samples with labels `N001`, `T001`, and `L001` that would all have different ALT IDs. This is changed from previous logic where the sample counter would increment based on total patient samples not just total patient samples of the same sample type.

---
## Crossing T's and dotting I's

Please follow these checklists to help prevent any unexpected issues from being introduced by the changes in this pull request. If an item does not apply then indicate so by surrounding the line item with `~~` to strikethrough the text. See [basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for more information.

### I. Data model checklist
Please follow these checks if any changes were made to any classes in the web, service, or persistence layers.

**Code checks:**
- [x] Unit tests were updated in relation to updates to the mocked test data.

### II. Message handlers checklist: **n/a**
```
- [ ] Changes introduced affect the workflow of incoming messages.
- [ ] Messages are following the expected workflow when published to the topic(s) changed or introduced in this pull request.
```

Please describe how the workflow and messaging was tested/simulated:

**Describe your testing environment:**

- NATS [local, local docker, **dev server**, production]
- Neo4j [local, local docker, **dev server**, production]
- SMILE Server [local, local docker, **dev server**, production]
- Message publishing simulation [nats cli, docker nats cli, **smile publisher tool**, other (describe below)]

Other: [insert details on how messages were published or simulated for testing]

### II. Configuration and/or permissions checklist: **n/a**
```
- [ ] New topics were introduced.
- [ ] The topics and appropriate permissions were updated in [smile-configuration](https://github.mskcc.org/cmo/smile-configuration).
- [ ] If applicable, a new account was set up and the account credentials and keys are checked into [smile-configuration](https://github.mskcc.org/cmo/smile-configuration).
- [ ] Account credentials and keys were shared with the appropriate parties.
```


---
### General checklist:
- [ ] All requested changes and comments have been resolved.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
