### PR TITLE
Added Tumor to CMO sample class mapping

### DIFF
--- a/src/main/java/org/mskcc/smile/service/impl/CmoLabelGeneratorServiceImpl.java
+++ b/src/main/java/org/mskcc/smile/service/impl/CmoLabelGeneratorServiceImpl.java
@@ -98,6 +98,7 @@ public class CmoLabelGeneratorServiceImpl implements CmoLabelGeneratorService {
      */
     private static Map<CmoSampleClass, String> initCmoSampleClassAbbrevMap() {
         Map<CmoSampleClass, String> map = new HashMap<>();
+        map.put(CmoSampleClass.TUMOR, "T");
         map.put(CmoSampleClass.UNKNOWN_TUMOR, "T");
         map.put(CmoSampleClass.LOCAL_RECURRENCE, "T");
         map.put(CmoSampleClass.PRIMARY, "T");


### PR DESCRIPTION
# Added Tumor to CMO sample class mapping

Briefly describe changes proposed in this pull request:
- Tumor was added as part of the CMO sample class direct mapping due to frequent asks for updating sample metadata from Tumor => Unknown Tumor to simply allow the label generator to succeed in making a new label for samples. 
- We confirmed that there is no significant distinction between Tumor and Unknown Tumor before adding this mapping (confirmed with Pavitra).
