### PR TITLE
Expand cfDNA logic for samples with no sample origin data

### DIFF
--- a/src/main/java/org/mskcc/smile/service/impl/CmoLabelGeneratorServiceImpl.java
+++ b/src/main/java/org/mskcc/smile/service/impl/CmoLabelGeneratorServiceImpl.java
@@ -62,6 +62,7 @@ public class CmoLabelGeneratorServiceImpl implements CmoLabelGeneratorService {
                     SampleOrigin.CEREBROSPINAL_FLUID,
                     SampleOrigin.PLASMA,
                     SampleOrigin.WHOLE_BLOOD);
+    private static final String CFDNA_ABBREV_DEFAULT = "L";
     private static final String SAMPLE_ORIGIN_ABBREV_DEFAULT = "T";
     private static final Set<String> SAMPLE_TYPE_TUMOR_ABBREVIATIONS
             = new HashSet<>(Arrays.asList("P", "M", "R", "T"));
@@ -566,6 +567,13 @@ public class CmoLabelGeneratorServiceImpl implements CmoLabelGeneratorService {
             CmoSampleClass sampleClass = CmoSampleClass.fromValue(cmoSampleClassValue);
             if (SAMPLE_CLASS_ABBREV_MAP.containsKey(sampleClass)) {
                 sampleTypeAbbreviation = SAMPLE_CLASS_ABBREV_MAP.get(sampleClass);
+            }
+            // if sample type abbreviation at this point is not normal and sample type detailed is cfDNA
+            // then return cfDNA abbreviation (L)
+            if (((specimenType != null && specimenType.equals(SpecimenType.CFDNA))
+                    || (sampleTypeDetailedValue != null && sampleTypeDetailedValue.equals("cfDNA")))
+                    && !sampleTypeAbbreviation.equals("N")) {
+                return CFDNA_ABBREV_DEFAULT;
             }
         } catch (Exception e) {
             // happens if cmoSampleClassValue is not found in CmoSampleClass

--- a/src/test/java/org/mskcc/smile/CmoLabelGeneratorServiceTest.java
+++ b/src/test/java/org/mskcc/smile/CmoLabelGeneratorServiceTest.java
@@ -559,6 +559,13 @@ public class CmoLabelGeneratorServiceTest {
         String label5 = cmoLabelGeneratorService.generateCmoSampleLabel(sm5,
                 DEFAULT_SAMPLES_BY_ALT_ID, DEFAULT_SAMPLES_BY_ALT_ID);
         Assertions.assertEquals("C-BRCD03-T001-d01", label5);
+
+        // sample type abbreviation expected to resolve to F
+        SampleMetadata sm6 = initSampleMetadata("12345_C_7", "", "C-BRCD03", "ABF-89D",
+                "Unknown Tumor", "Non-PDX", NucleicAcid.DNA, "",  "cfDNA");
+        String label6 = cmoLabelGeneratorService.generateCmoSampleLabel(sm6,
+                DEFAULT_SAMPLES_BY_ALT_ID, DEFAULT_SAMPLES_BY_ALT_ID);
+        Assertions.assertEquals("C-BRCD03-L001-d01", label6);
     }
 
     private SampleMetadata getSampleWithPrimaryIdAndLabel(String primaryId, String cmoSampleName) {


### PR DESCRIPTION
# Expand cfDNA logic for samples with no sample origin data

Briefly describe changes proposed in this pull request:
- cfDNA requests don't capture sample origin information anymore so these changes account for these projects